### PR TITLE
aes working

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/Storj/storj-crypto",
   "dependencies": {
+    "browserify-aes": "^1.0.6",
     "readable-stream": "^2.2.3"
   }
 }

--- a/src/crypto/createDecipheriv-browser.js
+++ b/src/crypto/createDecipheriv-browser.js
@@ -31,8 +31,6 @@ function DecryptStream(enc, key, iv) {
     self.algorithm.length = 128
   });
 
-  //this.iv = iv;
-
   stream.Transform.call(this);
 }
 
@@ -45,7 +43,6 @@ util.inherits(DecryptStream, stream.Transform);
 DecryptStream.prototype._transform = function(chunk, enc, callback) {
   console.log('chunk piped to from concat s')
   console.log(chunk)
-  //console.log(this.iv.length)
   var self = this;
   // window.crypto.subtle.decrypt(
   //   { 
@@ -107,6 +104,7 @@ DecryptStream.prototype._flush = function(callback) {
 
 module.exports = function(enc, key, iv) {
   // do webcrypto here
+  var decipher = ciphers.createDecipheriv(mode, key, iv)
   var ds = new DecryptStream(enc, key, iv)
   return ds
 }

--- a/src/crypto/createDecipheriv.js
+++ b/src/crypto/createDecipheriv.js
@@ -1,18 +1,22 @@
 'use strict'
 
-let webcrypto
-try {
-  webcrypto = window.crypto
-} catch (err) {
-  // not available, use the code below
-}
+var crypto = require('browserify-aes')
 
-if (webcrypto){
-  module.exports = require('./createDecipheriv-browser')
-} else {
-  // do node crypto here
-  var crypto = require('crypto')
+// NOTE: There is no streaming mode in AES-CTR for webcrypto
+// Streaming mode is used by the node implementation so
+// we resort to requiring AES in pure ja for now
+
+// let webcrypto
+// try {
+//   webcrypto = window.crypto
+// } catch (err) {
+//   // not available, use the code below
+// }
+
+//if (webcrypto){
+//  module.exports = require('./createDecipheriv-browser')
+//} else {
   module.exports = function(enc, key, iv) {
     return crypto.createDecipheriv(enc, key, iv)
   }
-}
+//}


### PR DESCRIPTION
Because webcrypto does not support streaming mode we must fallback to pure js aes implementation.

ref: https://github.com/libp2p/js-libp2p-crypto/pull/29#issuecomment-259743073